### PR TITLE
Translate documentation from ch to en

### DIFF
--- a/docs/en/development/template/components.md
+++ b/docs/en/development/template/components.md
@@ -1,0 +1,92 @@
+# Component development
+
+New image component development.
+
+## New types and methods of upper interface
+
+- Create a new ```ImgAttribute``` type:
+
+```go
+type ImgAttribute interface {
+	SetWidth(value string) ImgAttribute
+	SetHeight(value string) ImgAttribute
+	SetSrc(value string) ImgAttribute
+	GetContent() template.HTML
+}
+```
+
+- Add a method to the ```Template``` interface:
+
+```go
+type Template interface {
+	...
+	Image() types.ImgAttribute
+	...
+}
+```
+
+## Implementation with ```adminlte```
+
+- Implement ```ImgAttribute```
+
+Create a new ```image.go``` file under ```./template/adminlte/components```:
+
+```go
+package components
+
+import (
+	"github.com/chenhg5/go-admin/template/types"
+	"html/template"
+)
+
+type ImgAttribute struct {
+	Name   string
+	Witdh  string
+	Height string
+	Src    string
+}
+
+func (compo *ImgAttribute) SetWidth(value string) types.ImgAttribute {
+	compo.Witdh = value
+	return compo
+}
+
+func (compo *ImgAttribute) SetHeight(value string) types.ImgAttribute {
+	compo.Height = value
+	return compo
+}
+
+func (compo *ImgAttribute) SetSrc(value string) types.ImgAttribute {
+	compo.Src = value
+	return compo
+}
+
+func (compo *ImgAttribute) GetContent() template.HTML {
+	return ComposeHtml(compo.TemplateList, *compo, "image")
+}
+```
+
+- Implement ```Image()``` method
+
+Add following function to ```.template/adminlte/adminlte.go```:
+
+```go
+func (*Theme) Image() types.ImgAttribute {
+	return &components.ImgAttribute{
+		Name:   "image",
+		Witdh:  "50",
+		Height: "50",
+		Src:    "",
+	}
+}
+```
+
+- Add a static resource file
+
+Create ```image.tmpl``` file under ```.template/adminlte/resource/pages/components```
+
+- Execute in the root directory:
+
+```shell
+admincli compile
+```

--- a/docs/en/development/template/form.md
+++ b/docs/en/development/template/form.md
@@ -1,0 +1,1 @@
+# Form component development

--- a/docs/en/development/template/template.md
+++ b/docs/en/development/template/template.md
@@ -1,0 +1,40 @@
+# Template introduction
+
+The theme template is an abstract representation of UI, including a collection of components and static resources that are called in the plugin.
+The theme template in go-admin is represented by the ```Template``` interface.
+You need to implement the ```Template``` interface described below if you want to create your own UI theme.
+
+```go
+type Template interface {
+	// Components
+	Form() types.FormAttribute
+	Box() types.BoxAttribute
+	Col() types.ColAttribute
+	Image() types.ImgAttribute
+	SmallBox() types.SmallBoxAttribute
+	Label() types.LabelAttribute
+	Row() types.RowAttribute
+	Table() types.TableAttribute
+	DataTable() types.DataTableAttribute
+	Tree() types.TreeAttribute
+	InfoBox() types.InfoBoxAttribute
+	Paginator() types.PaginatorAttribute
+	AreaChart() types.AreaChartAttribute
+	ProgressGroup() types.ProgressGroupAttribute
+	LineChart() types.LineChartAttribute
+	BarChart() types.BarChartAttribute
+	ProductList() types.ProductListAttribute
+	Description() types.DescriptionAttribute
+	Alert() types.AlertAttribute
+	PieChart() types.PieChartAttribute
+	ChartLegend() types.ChartLegendAttribute
+	Tabs() types.TabsAttribute
+	Popup() types.PopupAttribute
+
+	// Builder methods
+	GetTmplList() map[string]string
+	GetAssetList() []string
+	GetAsset(string) ([]byte, error)
+	GetTemplate(bool) (*template.Template, string)
+}
+```

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,61 @@
+# Go-admin Documentation
+
+- [How to use, go-admin introduction](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/instruction.md)
+    - [How to use plugins](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/plugins/plugins.md)
+        - [Admin plugin: configuration, generation, data management](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/plugins/admin.md)
+            - Quick start
+                - Generate a configuration file using admincli
+                - Set access routing
+                - Initialize and load in the engine
+                - Set access menu
+            - Model file introduction and configuration
+                - Form
+                    - default
+                    - Plain text
+                    - Radio
+                    - Password
+                    - Rich text
+                    - File
+                    - Double selection box
+                    - Multiple selection
+                    - Icon drop-down selection box
+                - Info
+    - [Page customization](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/pages/pages.md)
+        - [Page modules](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/pages/modules.md)
+            - Panel
+            - Row
+            - Column
+        - [Page components](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/pages/components.md)
+            - InfoBox
+            - Button
+            - BarChart
+            - LineChart
+            - PieChart
+            - Label
+            - Popup
+            - Product
+            - SmallBox
+            - Table
+            - Tree
+            - Image
+            - Form
+            - Tabs
+    - [Set the menu](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/menus.md)
+    - [Set up administrators, manage roles and permissions](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/rcba.md)
+
+- Participate in development
+    - Develop a plugin
+        - Initialize the plugin
+        - Routing settings
+        - Processing request
+        - Return response
+        - Some helpers methods
+    - Develop an adapter
+        - Adapter introduction
+        - Implement the Use method
+        - Implement the Content method
+    - [Develop a theme template](https://github.com/chenhg5/go-admin/blob/master/docs/en/development/template/template.md)
+        - [Component development](https://github.com/chenhg5/go-admin/blob/master/docs/en/development/template/components.md)
+        - Form component development
+        - Static resource processing
+        - Use templates

--- a/docs/en/instruction/instruction.md
+++ b/docs/en/instruction/instruction.md
@@ -1,0 +1,135 @@
+# Go-admin usage
+
+Go-admin makes it easy to use in various web frameworks through various adapters.
+
+## Example
+
+Import ```$GOPATH/github.com/chenhg5/go-admin/examples/datamodel/admin.sql``` into the database.
+
+Gin example:
+
+```go
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	_ "github.com/chenhg5/go-admin/adapter/gin" // adapter must be imported, if not - you have to implement it yourself
+	"github.com/chenhg5/go-admin/engine"
+	"github.com/chenhg5/go-admin/plugins/admin"
+	"github.com/chenhg5/go-admin/modules/config"
+	"github.com/chenhg5/go-admin/examples/datamodel"
+)
+
+func main() {
+	r := gin.Default()
+
+    // initialize the go-admin engine object
+	eng := engine.Default()
+
+	// go-admin global configuration
+	cfg := config.Config{
+		DATABASE: []config.Database{
+			{
+			HOST:         "127.0.0.1",
+			PORT:         "3306",
+			USER:         "root",
+			PWD:          "root",
+			NAME:         "goadmin",
+			MAX_IDLE_CON: 50,
+			MAX_OPEN_CON: 150,
+			DRIVER:       "mysql",
+			},
+			},
+		DOMAIN: "localhost", // cookies will be set for this domain
+		PREFIX: "admin",
+		// STORE must be set and have write permissions, otherwise new administrator users cannot be added
+		STORE: config.Store{
+		    PATH:   "./uploads",
+		    PREFIX: "uploads",
+		},
+		LANGUAGE: "en",
+	}
+
+	// Generators： see https://github.com/chenhg5/go-admin/blob/master/examples/datamodel/tables.go
+	adminPlugin := admin.NewAdmin(datamodel.Generators)
+
+	// Add configuration and plugins, call the `Use` method to mount to the web framework
+	eng.AddConfig(cfg).AddPlugins(adminPlugin).Use(r)
+
+	r.Run(":9033")
+}
+```
+
+The corresponding steps are annotated, the use is very simple, only need to:
+
+- Define an adapter
+- Set global configuration items
+- Initialize the plugin
+- Set up plugins and configurations
+- Mount to the web framework
+
+More examples: [https://github.com/chenhg5/go-admin/tree/master/examples](https://github.com/chenhg5/go-admin/tree/master/examples)
+
+## Configuration
+
+```go
+package config
+
+import (
+	"html/template"
+)
+
+type Database struct {
+	HOST         string
+	PORT         string
+	USER         string
+	PWD          string
+	NAME         string
+	MAX_IDLE_CON int
+	MAX_OPEN_CON int
+	DRIVER       string
+
+	FILE string
+}
+
+type Store struct {
+	PATH   string
+	PREFIX string
+}
+
+type Config struct {
+	// Database configuration
+	DATABASE []Database
+
+	// Login domain name
+	DOMAIN string
+
+	// Website language
+	LANGUAGE string
+
+	// Global management prefix
+	PREFIX string
+
+	// Theme name
+	THEME string
+
+	// Uploads storage location
+	STORE Store
+
+	// Website title
+	TITLE string
+
+	// Sidebar logo
+	LOGO template.HTML
+
+	// Logo for collapsed sidebar
+	MINILOGO template.HTML
+
+	// Page to redirect to after login
+	INDEX string
+}
+
+```
+
+[Back to Contents](https://github.com/chenhg5/go-admin/blob/master/docs/en/index.md)<br>
+[Next: Plugins](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/plugins/plugins.md)

--- a/docs/en/instruction/menus.md
+++ b/docs/en/instruction/menus.md
@@ -1,0 +1,3 @@
+# How to set the menu
+
+Login => Go to the home page => Manage/Menu Management

--- a/docs/en/instruction/pages/modules.md
+++ b/docs/en/instruction/pages/modules.md
@@ -1,0 +1,81 @@
+# Page Modularity
+
+Call the engine's ```Content``` method, that returns an object ```types.Panel``` for page customization
+
+```types.Panel``` definition：
+
+```go
+type Panel struct {
+	Content     template.HTML // page content
+	Title       string        // page title
+	Description string        // page description
+	Url         string
+}
+```
+
+![](https://ws3.sinaimg.cn/large/006tNbRwly1fxoz5bm02oj31ek0u0wtz.jpg)
+
+## Usage
+
+```go
+package datamodel
+
+import (
+	"github.com/chenhg5/go-admin/modules/config"
+	template2 "github.com/chenhg5/go-admin/template"
+	"github.com/chenhg5/go-admin/template/types"
+	"html/template"
+)
+
+func GetContent() types.Panel {
+
+	components := template2.Get(config.Get().THEME)
+	colComp := components.Col()
+
+	infobox := components.InfoBox().
+		SetText("CPU TRAFFIC").
+		SetColor("blue").
+		SetNumber("41,410").
+		SetIcon("ion-ios-gear-outline").
+		GetContent()
+
+	var size = map[string]string{"md": "3", "sm": "6", "xs": "12"}
+	infoboxCol1 := colComp.SetSize(size).SetContent(infobox).GetContent()
+	row1 := components.Row().SetContent(infoboxCol1).GetContent()
+
+	return types.Panel{
+		Content:     row1,
+		Title:       "Dashboard",
+		Description: "this is a example",
+	}
+}
+```
+
+## Column
+
+Column is represented by the ```ColAttribute``` interface：
+
+```go
+type ColAttribute interface {
+	SetSize(value map[string]string) ColAttribute
+	SetContent(value template.HTML) ColAttribute
+	GetContent() template.HTML
+}
+```
+
+```size``` looks like: ```map[string]string{"md": "3", "sm": "6", "xs": "12"}```
+
+## Row
+
+Row is represented by the ```RowAttribute``` interface:
+
+```go
+type RowAttribute interface {
+	SetContent(value template.HTML) RowAttribute
+	GetContent() template.HTML
+}
+```
+
+[Back to Contents](https://github.com/chenhg5/go-admin/blob/master/docs/en/index.md)<br>
+[Previous: Page Customization](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/pages/pages.md)<br>
+[Next: Page Components](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/pages/components.md)

--- a/docs/en/instruction/pages/pages.md
+++ b/docs/en/instruction/pages/pages.md
@@ -1,0 +1,84 @@
+# Page Customization
+
+Call the ```Content``` method of the engine:
+
+```go
+package main
+
+import (
+	_ "github.com/chenhg5/go-admin/adapter/gin"
+	"github.com/chenhg5/go-admin/engine"
+	"github.com/chenhg5/go-admin/examples/datamodel"
+	"github.com/chenhg5/go-admin/modules/config"
+	"github.com/chenhg5/go-admin/plugins/admin"
+	"github.com/chenhg5/go-admin/plugins/example"
+	"github.com/chenhg5/go-admin/template/types"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	eng := engine.Default()
+	cfg := config.Config{}
+
+	adminPlugin := admin.NewAdmin(datamodel.Generators)
+	examplePlugin := example.NewExample()
+
+	if err := eng.AddConfig(cfg).AddPlugins(adminPlugin, examplePlugin).Use(r); err != nil {
+		panic(err)
+	}
+
+	r.Static("/uploads", "./uploads")
+
+	// custom page endpoint
+	r.GET("/"+cfg.PREFIX+"/custom", func(ctx *gin.Context) {
+		engine.Content(ctx, func() types.Panel {
+			return datamodel.GetContent()
+		})
+	})
+
+	r.Run(":9033")
+}
+```
+
+The ```Content``` method will write the content to the ```context``` of the framework.
+
+```GetContent``` method implementation：
+
+```go
+package datamodel
+
+import (
+	"github.com/chenhg5/go-admin/modules/config"
+	template2 "github.com/chenhg5/go-admin/template"
+	"github.com/chenhg5/go-admin/template/types"
+	"html/template"
+)
+
+func GetContent() types.Panel {
+
+	components := template2.Get(config.Get().THEME)
+	colComp := components.Col()
+
+	infobox := components.InfoBox().
+		SetText("CPU TRAFFIC").
+		SetColor("blue").
+		SetNumber("41,410").
+		SetIcon("ion-ios-gear-outline").
+		GetContent()
+
+	var size = map[string]string{"md": "3", "sm": "6", "xs": "12"}
+	infoboxCol1 := colComp.SetSize(size).SetContent(infobox).GetContent()
+	row1 := components.Row().SetContent(infoboxCol1).GetContent()
+
+	return types.Panel{
+		Content:     row1,
+		Title:       "Dashboard",
+		Description: "this is a example",
+	}
+}
+```
+
+[Back to Contents](https://github.com/chenhg5/go-admin/blob/master/docs/en/index.md)<br>
+[Previous: Admin Plugin](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/plugins/admin.md)<br>
+[Next page: Modules Introduction](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/pages/modules.md)

--- a/docs/en/instruction/plugins/admin.md
+++ b/docs/en/instruction/plugins/admin.md
@@ -1,0 +1,269 @@
+# Admin Plugin Usage
+
+The admin plugin can help you to quickly generate a database data table for adding, deleting, and changing database data tables.
+
+## Quick start
+- Generate a configuration file corresponding to the data table
+- Set access routing
+- Initialize and load in the engine
+- Set access menu
+
+### Generate the configuration file
+
+Suppose you have a data table users in your database, for example:
+
+```sql
+CREATE TABLE `users` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `gender` tinyint(4) DEFAULT NULL,
+  `city` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `ip` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `phone` varchar(10) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3635 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+Use the included command line tools to help you quickly generate configuration files, for example:
+
+- Installation
+
+```bash
+go install github.com/chenhg5/go-admin/admincli
+```
+
+- Generation
+
+```bash
+admincli generate -h=127.0.0.1 -p=3306 -u=root -P=root -pa=main -n=goadmin -o=./
+
+-h  host
+-p  port
+-u  username
+-P  password
+-n  database name
+-pa package name
+-o  output file path
+
+```
+
+The file ```users.go``` will be generated. This is the configuration file corresponding to the data table. Configuration details described later.
+
+### Set access routing
+
+After generating the configuration file, you need to set the route to access the data of this data table, for example:
+
+```go
+package datamodel
+
+import "github.com/chenhg5/go-admin/plugins/admin/models"
+
+// The key of Generators is the prefix of table info url.
+// The corresponding value is the Form and Table data.
+var Generators = map[string]models.TableGenerator{
+	"user":    GetUserTable,
+}
+```
+
+```"user"``` is the prefix of the table info url ```GetUserTable``` is the method in the configuration file
+
+### Initialize and load the engine
+
+To initialize, you need to call the ```NewAdmin``` method, and then pass the ```Generators``` defined above. Then call the engine's ```AddPlugins``` method to load the engine.
+
+```go
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	_ "github.com/chenhg5/go-admin/adapter/gin" // adapter must be imported, if not - you have to implement it yourself
+	"github.com/chenhg5/go-admin/engine"
+	"github.com/chenhg5/go-admin/plugins/admin"
+	"github.com/chenhg5/go-admin/modules/config"
+	"github.com/chenhg5/go-admin/examples/datamodel"
+)
+
+func main() {
+	r := gin.Default()
+	eng := engine.Default()
+	cfg := config.Config{}
+
+	adminPlugin := admin.NewAdmin(datamodel.Generators)
+
+	eng.AddConfig(cfg).
+		AddPlugins(adminPlugin). // Load plugin
+		Use(r)
+
+	r.Run(":9033")
+}
+```
+
+### Set access routing
+
+After running visit the login URL, go to the menu management page. The management menu for setting up the data table can be accessed in the sidebar.
+
+## Profile introduction
+
+Configuration file can looks like:
+
+```go
+package main
+
+import (
+	"github.com/chenhg5/go-admin/template/types"
+	"github.com/chenhg5/go-admin/plugins/admin/models"
+)
+
+func GetUsersTable() (usersTable models.Table) {
+
+	usersTable.Info.FieldList = []types.Field{}
+
+	usersTable.Info.Table = "users"
+	usersTable.Info.Title = "Users"
+	usersTable.Info.Description = "Users"
+
+	usersTable.Form.FormList = []types.Form{}
+
+	usersTable.Form.Table = "users"
+	usersTable.Form.Title = "Users"
+	usersTable.Form.Description = "Users"
+
+	usersTable.ConnectionDriver = "mysql"
+
+	return
+}
+```
+```GetUsersTable``` returns the object with type ```models.Table```. See the ```models.Table``` definition below:
+
+```go
+type Table struct {
+	Info             types.InfoPanel
+	Form             types.FormPanel
+	ConnectionDriver string
+}
+```
+
+Both ```Info``` and ```Form``` are UI components responsible for displaying table title with description and editing new data respectively
+
+- ```Info```
+
+![](https://ws4.sinaimg.cn/large/006tNbRwly1fxoy26qnc5j31y60u0q91.jpg)
+
+- ```Form```
+
+![](https://ws1.sinaimg.cn/large/006tNbRwly1fxoy2w3cobj318k0ooabv.jpg)
+
+### Info Panel
+
+```go
+type InfoPanel struct {
+	FieldList   []Field
+	Table       string
+	Title       string
+	Description string
+}
+
+type Field struct {
+	ExcuFun  FieldValueFun // filter function
+	Field    string        // field name
+	TypeName string        // field type name
+	Head     string        // title
+	Sortable bool
+	Filter   bool
+}
+```
+
+### Form Panel
+
+```go
+type FormPanel struct {
+	FormList   []Form
+	Table       string
+	Title       string
+	Description string
+}
+
+type Form struct {
+	Field    string  // field name
+	TypeName string  // field type name
+	Head     string  // title
+	Default  string
+	Editable bool
+	FormType string
+	Value    string
+	Options  []map[string]string
+	ExcuFun  FieldValueFun // filter function
+}
+```
+
+Currently supported form types are:
+- Default
+- Text
+- SelectSingle
+- Select
+- IconPicker
+- SelectBox
+- File
+- Password
+- RichText
+- Datetime
+- Radio
+- Email
+- Url
+- Ip
+- Color
+- Currency
+- Number
+
+For example:
+
+```go
+
+import "github.com/chenhg5/go-admin/template/types/form"
+
+...
+FormType: form.File,
+...
+
+```
+
+For the selection type: `SelectSingle`, `Select`, `SelectBox` you must specify `Options` field：
+
+```go
+...
+Options: []map[string]string{
+	{
+        "field": "name", // the name of the field
+        "value": "Adam", // value you can select from
+    },{
+        "field": "name",
+        "value": "John",
+    },
+}
+...
+```
+
+### Filter function `ExcuFun`
+
+```go
+// RowModel contains ID and value of the single query result.
+type RowModel struct {
+	ID    int64
+	Value string
+}
+
+// FieldValueFun is filter function of data.
+type FieldValueFun func(value RowModel) interface{}
+```
+
+The filter function receives a parameter, RowModel, which represents the current edit target line, contains the id and the displayed value.
+The return value of the filter function is the default value displayed by the final form line.
+
+In the table, you can customize the html return.
+In the form, for non-selected form types, you **must** return `string`. For single-select, multi-select, etc., select form type, return `[]string`.
+
+[Back to Contents](https://github.com/chenhg5/go-admin/blob/master/docs/en/index.md)<br>
+[Previous: Plugins](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/plugins/plugins.md)<br>
+[Next page: Custom page](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/pages/pages.md)

--- a/docs/en/instruction/plugins/plugins.md
+++ b/docs/en/instruction/plugins/plugins.md
@@ -1,0 +1,38 @@
+# Plugins Usage
+
+To use the plugin, just call the `AddPlugins` method of the engine.
+
+Example:
+
+```go
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	_ "github.com/chenhg5/go-admin/adapter/gin" // adapter must be imported, if not - you have to implement it yourself
+	"github.com/chenhg5/go-admin/engine"
+	"github.com/chenhg5/go-admin/plugins/admin"
+	"github.com/chenhg5/go-admin/plugins/example"
+	"github.com/chenhg5/go-admin/modules/config"
+	"github.com/chenhg5/go-admin/examples/datamodel"
+)
+
+func main() {
+	r := gin.Default()
+	eng := engine.Default()
+	cfg := config.Config{}
+
+	adminPlugin := admin.NewAdmin(datamodel.Generators)
+	examplePlugin := example.NewExample()
+
+	eng.AddConfig(cfg).
+		AddPlugins(adminPlugin, examplePlugin). // Load plugin
+		Use(r)
+
+	r.Run(":9033")
+}
+```
+
+[Back to Contents](https://github.com/chenhg5/go-admin/blob/master/docs/en/index.md)<br>
+[Previous:go-admin introduction](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/instruction.md)<br>
+[Next: Admin plugin](https://github.com/chenhg5/go-admin/blob/master/docs/en/instruction/plugins/admin.md)

--- a/docs/en/instruction/rcba.md
+++ b/docs/en/instruction/rcba.md
@@ -1,0 +1,3 @@
+# Administrator and administrative privileges
+
+Login => Go to the home page => Manage/Role


### PR DESCRIPTION
Added English translation for documentation.

@chenhg5 if there is any other documentation exists - please notify me, I'll try to help with the translation.

I've also found the [misspell](https://github.com/chenhg5/go-admin/blob/master/template/components/image.go#L10)
`Witdh` => `Width`
